### PR TITLE
Streamlined sourcing and grouping all virtualenv folders in one folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ see: http://www.doughellmann.com/projects/virtualenvwrapper/
 see: https://github.com/pypa/virtualenv
 
 ###Setup:
-Pretty straightforward, in a .profile or .bashrc or .bash_profile add the following lines:
+Pretty straightforward, clone the repository
+`git clone https://github.com/aubricus/nodeenvwrapper.git $HOME/.nodeenvwrapper`
+
+and in a .profile or .bashrc or .bash_profile add the following lines:
 ```
-export NODEENVWRAPPER_SCRIPT=/path/to/nodeenvwrapper.sh
 export NODEENV_HOME=$HOME/.nodeenv
-source $NODEENVWRAPPER_SCRIPT
+source /path/to/nodeenvwrapper.sh
 ```
 That should get it working, though you may need to restart your terminal session depending on your setup.
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ see: http://www.doughellmann.com/projects/virtualenvwrapper/
 
 see: https://github.com/pypa/virtualenv
 
-###Setup: 
+###Setup:
 Pretty straightforward, in a .profile or .bashrc or .bash_profile add the following lines:
 ```
 export NODEENVWRAPPER_SCRIPT=/path/to/nodeenvwrapper.sh
 export NODEENV_HOME=$HOME/.nodeenv
-source NODEENVWRAPPER_SCRIPT
+source $NODEENVWRAPPER_SCRIPT
 ```
 That should get it working, though you may need to restart your terminal session depending on your setup.
 
@@ -28,7 +28,7 @@ alias dnenv='deactivate_node'
 ###Notes:
 I did not write nodeenv, this is just a simple util to improve it's workflow.
 
-Doug Hellmann's virtualenvwrapper is well written and well tested across many shells and environments. This code is not. I run this in bash on my OSX machine running Lion (OSX 10.7.4). As such this code may fail miserably for you. Feel free to fork / pull request if you like! 
+Doug Hellmann's virtualenvwrapper is well written and well tested across many shells and environments. This code is not. I run this in bash on my OSX machine running Lion (OSX 10.7.4). As such this code may fail miserably for you. Feel free to fork / pull request if you like!
 
 In general this follows the same conventions as virtualenvwrapper.Unlike virtualenvwrapper however there are no real safeguards / checks when this thing is modifying your folder structure. I've tried to keep the below clean but my shell scripting is only so-so. PLEASE USE CAUTION when running these utility methods!
 

--- a/nodeenvwrapper.sh
+++ b/nodeenvwrapper.sh
@@ -3,7 +3,7 @@
 # see: http://www.doughellmann.com/projects/virtualenvwrapper/
 # see: https://github.com/pypa/virtualenv
 
-# Copyright 2012 Aubrey Taylor 
+# Copyright 2012 Aubrey Taylor
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # see: http://github.com/aubricus/nodeenvwrapper for documentation and notes.
 
 # mknodenv
@@ -26,14 +26,14 @@
 mknodeenv(){
 	node_env=$1
 	args=${*:2}
-	
+
 	type deactivate_node >/dev/null 2>&1
 
-	if [ $? -eq 0 ]; then	
+	if [ $? -eq 0 ]; then
 		deactivate_node
 	fi
 
-	nodeenv "$NODEENV_HOME$node_env" $args
+	nodeenv "$NODEENV_HOME/$node_env" $args
 	workon_nodeenv $node_env
 }
 
@@ -42,14 +42,14 @@ mknodeenv(){
 # takes param $env_name, e.g. 'workon_nodeenv my_env'
 workon_nodeenv(){
 	node_env=$1
-	
-	type deactivate_node >/dev/null 2>&1	
-	
+
+	type deactivate_node >/dev/null 2>&1
+
 	if [ $? -eq 0 ]; then
 		deactivate_node
 	fi
-	
-	source "$NODEENV_HOME$node_env/bin/activate"
+
+	source "$NODEENV_HOME/$node_env/bin/activate"
 }
 
 # rmnodeenv
@@ -57,7 +57,7 @@ workon_nodeenv(){
 # takes param $env_name, e.g. 'rmnodeenv my_env'
 rmnodeenv(){
 	node_env=$1
-	rm -r "$NODEENV_HOME$node_env"
+	rm -r "$NODEENV_HOME/$node_env"
 }
 
 # cdnodeenv
@@ -65,7 +65,7 @@ rmnodeenv(){
 # takes param $env_name, e.g. 'cdnodeenv my_env'
 cdnodeenv(){
 	node_env=$1
-	cd "$NODEENV_HOME$node_env"
+	cd "$NODEENV_HOME/$node_env"
 }
 
 # lsnodeenv


### PR DESCRIPTION
Streamlined sourcing of nodeenvwrapper.sh into oneline as the NODEEVNWRAPPER_SCRIPT environment variable weren't used anywhere. Also added a git clone reference into README to be beginner friendly and also more comprehensive in guiding users.

Changed pathing structure when making and using nodeenvs from $NODEENV_HOMEmynodeenv to $NODEENV_HOME/mynodeenv. This way all nodeenvs are contained into one folder and the root folder containing $NODEENV_HOME isn't populated with your nodeenvs as well as with the $NODEENV_HOME, which in that case would remain empty.

This fixes #2
